### PR TITLE
update errorformat, use cf filetype, use standard plugin paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 The beginnings of a cflint syntastic script.
 
 In .vimrc, add `let g:syntastic_cfml_checkers=['cflint']`
+
+## Install
+
+cflint-syntastic follows the standard runtime path structure.  Using
+a common and well known plugin manager to install cflint-syntastic is recommended.
+For Pathogen just clone the repo, for other plugin managers
+add the appropriate lines and execute the plugin's install command.
+
+*  [Pathogen](https://github.com/tpope/vim-pathogen)
+  * `git clone https://github.com/cflint/cflint-syntastic.git ~/.vim/bundle/cflint-syntastic`
+*  [vim-plug](https://github.com/junegunn/vim-plug)
+  * `Plug 'cflint/cflint-syntastic'`
+*  [NeoBundle](https://github.com/Shougo/neobundle.vim)
+  * `NeoBundle 'cflint/cflint-syntastic'`
+*  [Vundle](https://github.com/gmarik/vundle)
+  * `Plugin 'cflint/cflint-syntastic'`
+
+Please make sure `cflint` is [installed](https://github.com/cflint/CFLint/blob/master/build-instructions.md)
+and in the PATH.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 The beginnings of a cflint syntastic script.
 
-In .vimrc, add `let g:syntastic_cfml_checkers=['cflint']`
 
 ## Install
 
@@ -20,3 +19,6 @@ add the appropriate lines and execute the plugin's install command.
 
 Please make sure `cflint` is [installed](https://github.com/cflint/CFLint/blob/master/build-instructions.md)
 and in the PATH.
+
+## Disable
+In .vimrc, add `let g:syntastic_cf_checkers=[]`

--- a/syntax_checkers/cf/cflint.vim
+++ b/syntax_checkers/cf/cflint.vim
@@ -1,20 +1,20 @@
-if exists("g:loaded_syntastic_cfml_cflint_checker")
+if exists("g:loaded_syntastic_cf_cflint_checker")
 	finish
 endif
-let g:loaded_syntastic_cfml_cflint_checker = 1
+let g:loaded_syntastic_cf_cflint_checker = 1
 
-"if !exists('g:syntastic_cfml_sort')
-	"let g:syntastic_cfml_sort = 1
+"if !exists('g:syntastic_cf_sort')
+	"let g:syntastic_cf_sort = 1
 "endif
 
 let s:save_cpo = &cpo
 set cpo&vim
 
-function! SyntaxCheckers_cfml_IsAvailable() dict
+function! SyntaxCheckers_cf_IsAvailable() dict
 	return executable(self.getExec())
 endfunction
 
-"function! SyntaxCheckers_cfml_GetHighLightRegex(item)
+"function! SyntaxCheckers_cf_GetHighLightRegex(item)
 	"if match(a:item['text'], 'assigned but not unused variable') > -1
 		"let term = split(a:item['text'], ' - ')[1]
 		"return '\V\\<'.term.'\\>'
@@ -23,7 +23,7 @@ endfunction
 	"return ''
 "endfunction
 
-function! SyntaxCheckers_cfml_cflint_GetLocList() dict
+function! SyntaxCheckers_cf_cflint_GetLocList() dict
 	let makeprg = self.makeprgBuild({
 				\ 'args': '-file',
 				\ 'args_after': '-text' })
@@ -36,7 +36,7 @@ function! SyntaxCheckers_cfml_cflint_GetLocList() dict
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({
-			\ 'filetype': 'cfml',
+			\ 'filetype': 'cf',
 			\ 'name': 'cflint' })
 
 let &cpo = s:save_cpo

--- a/syntax_checkers/cf/cflint.vim
+++ b/syntax_checkers/cf/cflint.vim
@@ -1,18 +1,35 @@
+"============================================================================
+"File:        cflint.vim
+"Description: Syntax checking plugin for cflint-syntastic
+"
+"============================================================================
+" See http://vimdoc.sourceforge.net/htmldoc/quickfix.html#efm-ignore
+" 
+" Sample Follows
+"
+"
+" Severity:ERROR
+" Message code:PARSE_ERROR
+" 	File:/home/displague/t.cfm
+" 	Column:8
+" 	Line:2
+" 		Message:Unable to parse
+" 		Variable:'null' in function: 
+" 		Expression:[@5,9:9=';',<65>,2:8]
+"
+
 if exists("g:loaded_syntastic_cf_cflint_checker")
 	finish
 endif
 let g:loaded_syntastic_cf_cflint_checker = 1
 
-"if !exists('g:syntastic_cf_sort')
-	"let g:syntastic_cf_sort = 1
-"endif
 
 let s:save_cpo = &cpo
 set cpo&vim
 
-function! SyntaxCheckers_cf_IsAvailable() dict
-	return executable(self.getExec())
-endfunction
+function! SyntaxCheckers_cf_IsAvailable() dict " {{{1
+	return executable(expand(self.getExec(), 1))
+endfunction " }}}1
 
 "function! SyntaxCheckers_cf_GetHighLightRegex(item)
 	"if match(a:item['text'], 'assigned but not unused variable') > -1
@@ -23,17 +40,49 @@ endfunction
 	"return ''
 "endfunction
 
-function! SyntaxCheckers_cf_cflint_GetLocList() dict
+" @vimlint(EVL104, 1, l:errorformat)
+function! SyntaxCheckers_cf_cflint_GetLocList() dict " {{{1
 	let makeprg = self.makeprgBuild({
-				\ 'args': '-file',
-				\ 'args_after': '-text' })
+				\ 'args': '-q -text',
+				\ 'args_after': '-file' })
 
-	let errorformat = '%f:%l [%t] %m'
+	let errorformat = 
+		\ '%-GPicked%.%#,'.
+		\ '%-Gline%.%#,'.
+		\ '%-GStage%.%#,'.
+		\ '%-Gline%.%#,'.
+		\ '%-GIssue%.%#,'.
+		\ '%ESeverity:ERROR'.','.
+		\ '%ESeverity:FATAL'.','.
+		\ '%ESeverity:CRITICAL'.','.
+		\ '%WSeverity:WARNING'.','.
+		\ '%WSeverity:CAUTION'.','.
+		\ '%ISeverity:INFO'.','.
+		\ '%ISeverity:COSMETIC'.','.
+		\ '%CMessage code:%.%#'.','.
+		\ '%C%\tFile:%f'.','.
+		\ '%C%\tColumn:%c'.','.
+		\ '%C%\tLine:%l'.','.
+		\ '%C%\t%\tMessage:%m'.','.
+		\ '%C%\t%\tVariable:'."'".'%.%#'."'".' in function\: %.%#'.','.
+		\ '%Z%\t%\tExpression:%.%#'.','.
+		\ '%-G%.%#'
+
+	" Other lines should be hidden
+	"let errorformat .= '%-G%.%#'
+
+	if !exists('g:syntastic_cf_cflint_sort')
+	    let g:syntastic_cf_cflint_sort = 1
+	endif
 
 	let env = { 'CFMLOPT': '' }
 
-	return SyntasticMake({ 'makeprg': makeprg, 'errorformat': errorformat, 'env': env })
-endfunction
+	return SyntasticMake({
+		\ 'makeprg': makeprg,
+		\ 'errorformat': errorformat,
+		\ 'env': env })
+endfunction " }}}1
+" @vimlint(EVL104, 0, l:errorformat)
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({
 			\ 'filetype': 'cf',


### PR DESCRIPTION
After this change, parsing works and `:SyntasticInfo` shows:

```
Syntastic version: 3.6.0-77 (Vim 704, Linux)
Info for filetype: cf
Global mode: active
Passive filetype: html
Filetype cf is active
The current file will be checked automatically
Available checker: cflint
Currently enabled checker: cflint
Press ENTER or type command to continue
```
